### PR TITLE
Update to coding-standard ^0.7

### DIFF
--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -1,0 +1,5 @@
+<?php declare(strict_types=1);
+
+use IxDFCodingStandard\PhpCsFixer\Config;
+
+return Config::create(__DIR__);

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "laravel/nova": "^4.20 || ^5.0"
     },
     "require-dev": {
-        "interaction-design-foundation/coding-standard": "^0.4 || ^0.5 || ^0.6",
+        "interaction-design-foundation/coding-standard": "^0.7",
         "orchestra/testbench-core": "^10.0.2 || ^11.0",
         "phpunit/phpunit": "^10.5 || ^11.0 || ^12.0",
         "vimeo/psalm": "^6.0"

--- a/src/Unlayer.php
+++ b/src/Unlayer.php
@@ -84,7 +84,7 @@ class Unlayer extends Field
 
     /**
      * Specify javascript modules to process Unlayer’s design on every design change.
-     * @param string[] $plugins
+     * @param array<string> $plugins
      */
     final public function plugins(array $plugins): static
     {
@@ -99,9 +99,7 @@ class Unlayer extends Field
         return $this;
     }
 
-    /**
-     * Set the visual height of the Code editor to automatic.
-     */
+    /** Set the visual height of the Code editor to automatic. */
     public function autoHeight(): static
     {
         $this->height = 'auto';
@@ -109,9 +107,7 @@ class Unlayer extends Field
         return $this;
     }
 
-    /**
-     * Set the visual height of the Unlayer editor (with units).
-     */
+    /** Set the visual height of the Unlayer editor (with units). */
     public function height(string $height): static
     {
         $this->height = $height;

--- a/tests/UnlayerTest.php
+++ b/tests/UnlayerTest.php
@@ -34,7 +34,7 @@ final class UnlayerTest extends TestCase
     #[Test]
     public function it_properly_runs_saving_callback(): void
     {
-        $inMemoryModel = new class extends Model {
+        $inMemoryModel = new class () extends Model {
             public string $design = '';
             public string $html = '';
         };


### PR DESCRIPTION
## Summary
- Updates `interaction-design-foundation/coding-standard` constraint from `^0.4 || ^0.5 || ^0.6` to `^0.7`
- Adds `.php-cs-fixer.php` config using the shared `IxDFCodingStandard\PhpCsFixer\Config::create()` factory
- Applies code style fixes from the new php-cs-fixer ruleset

## Test plan
- [x] `composer update` succeeds
- [x] `vendor/bin/phpunit` passes (5 tests, 8 assertions)
- [x] `vendor/bin/phpcs` passes
- [x] `vendor/bin/php-cs-fixer fix --dry-run` passes after fixes applied