### PR TITLE
Require PHP 8.4, adopt Psalm 7 + plugins, fix CI matrix

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -8,15 +8,14 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php: [ 8.5, 8.4, 8.3, 8.2 ]
-        laravel: [ 12.* ]
+        php: [ 8.5, 8.4 ]
+        laravel: [ 12.*,  13.*  ]
         dependency-version: [ prefer-stable ]
         include:
           - laravel: 12.*
             testbench: 10.*
-          # L13 matrix entry ready for when laravel/nova supports it:
-          # - laravel: 13.*
-          #   testbench: 11.*
+          - laravel: 13.*
+            testbench: 11.*
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.dependency-version }}
 

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ auth.json
 phpunit.xml
 .phpunit.result.cache
 .phpunit.cache
+.php-cs-fixer.cache
+/.cache

--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -2,4 +2,4 @@
 
 use IxDFCodingStandard\PhpCsFixer\Config;
 
-return Config::create(__DIR__);
+return Config::create(__DIR__, ruleOverrides: []);

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "interaction-design-foundation/psalm-laravel-nova": "^0.1",
         "orchestra/testbench-core": "^10.0.2 || ^11.0",
         "phpunit/phpunit": "^12.4",
-        "psalm/plugin-laravel": "^4.14.12",
+        "psalm/plugin-laravel": "^4.14",
         "vimeo/psalm": "^7.0.0-beta19"
     },
     "repositories": [

--- a/composer.json
+++ b/composer.json
@@ -9,15 +9,17 @@
         "html"
     ],
     "require": {
-        "php": "^8.2",
+        "php": "^8.4",
         "ext-json": "*",
         "laravel/nova": "^4.20 || ^5.0"
     },
     "require-dev": {
         "interaction-design-foundation/coding-standard": "^1.0-RC1",
+        "interaction-design-foundation/psalm-laravel-nova": "^0.1",
         "orchestra/testbench-core": "^10.0.2 || ^11.0",
-        "phpunit/phpunit": "^10.5 || ^11.0 || ^12.0",
-        "vimeo/psalm": "^6.0"
+        "phpunit/phpunit": "^12.4",
+        "psalm/plugin-laravel": "^4.14.12",
+        "vimeo/psalm": "^7.0.0-beta19"
     },
     "repositories": [
         {
@@ -42,8 +44,8 @@
     },
     "config": {
         "allow-plugins": {
-            "ergebnis/composer-normalize": true,
-            "dealerdirect/phpcodesniffer-composer-installer": true
+            "dealerdirect/phpcodesniffer-composer-installer": true,
+            "ergebnis/composer-normalize": true
         },
         "sort-packages": true
     },
@@ -55,9 +57,13 @@
         }
     },
     "scripts": {
-        "cs": "@cs:fix",
-        "cs:check": "phpcs -p -s --colors --report-full --report-summary",
-        "cs:fix": "phpcbf -p --colors",
+        "cs": [
+            "@php-cs-fixer",
+            "@phpcbf"
+        ],
+        "php-cs-fixer": "php-cs-fixer fix --no-interaction --ansi --quiet",
+        "phpcbf": "phpcbf -p",
+        "phpcs": "phpcs -p -s --report-full --report-summary",
         "psalm": "vendor/bin/psalm",
         "sa": "@psalm",
         "sa:bl": "cpx psalm --set-baseline=psalm-baseline.xml --long-progress --threads=1",

--- a/package.json
+++ b/package.json
@@ -21,5 +21,7 @@
         "postcss": "8.5.15",
         "vue-loader": "16.8.3"
     },
-    "dependencies": {}
+    "overrides": {
+        "webpack": "5.74.0"
+    }
 }

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,21 +1,3 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="5.26.1@d747f6500b38ac4f7dfc5edbcae6e4b637d7add0">
-  <file src="src/Unlayer.php">
-    <MethodSignatureMismatch>
-      <code><![CDATA[Unlayer]]></code>
-    </MethodSignatureMismatch>
-    <MixedArgument>
-      <code><![CDATA[$request->get($requestAttribute)]]></code>
-    </MixedArgument>
-    <MixedAssignment>
-      <code><![CDATA[$attributeValue]]></code>
-    </MixedAssignment>
-    <MoreSpecificImplementedParamType>
-      <code><![CDATA[$model]]></code>
-    </MoreSpecificImplementedParamType>
-    <PropertyNotSetInConstructor>
-      <code><![CDATA[Unlayer]]></code>
-      <code><![CDATA[Unlayer]]></code>
-    </PropertyNotSetInConstructor>
-  </file>
+<files psalm-version="7.0.0-beta19@7e751c06a756fa64dc4c759c09fe4a173afcb433">
 </files>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,3 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <files psalm-version="7.0.0-beta19@7e751c06a756fa64dc4c759c09fe4a173afcb433">
+  <file src="src/Unlayer.php">
+    <MoreSpecificImplementedParamType>
+      <code><![CDATA[$model]]></code>
+    </MoreSpecificImplementedParamType>
+  </file>
+  <file src="vendor/laravel/nova/src/Fields/SupportsDependentFields.php">
+    <InternalClass>
+      <code><![CDATA[new Dependent($attributes, $mixin)]]></code>
+      <code><![CDATA[new Dependent($attributes, $mixin, 'create')]]></code>
+      <code><![CDATA[new Dependent($attributes, $mixin, 'update')]]></code>
+    </InternalClass>
+    <PossiblyInvalidArgument>
+      <code><![CDATA[$mixin]]></code>
+      <code><![CDATA[$mixin]]></code>
+      <code><![CDATA[$mixin]]></code>
+    </PossiblyInvalidArgument>
+  </file>
 </files>

--- a/psalm.xml
+++ b/psalm.xml
@@ -11,14 +11,12 @@
 >
     <projectFiles>
         <directory name="src"/>
-        <ignoreFiles>
-            <directory name="vendor"/>
-        </ignoreFiles>
     </projectFiles>
+
     <disableExtensions>
-        <extension name="random"/>
         <extension name="redis"/>
     </disableExtensions>
+
     <plugins>
         <pluginClass class="Psalm\LaravelPlugin\Plugin">
             <experimental value="true"/>

--- a/psalm.xml
+++ b/psalm.xml
@@ -10,13 +10,20 @@
     errorBaseline="psalm-baseline.xml"
 >
     <projectFiles>
-        <directory name="src" />
+        <directory name="src"/>
         <ignoreFiles>
-            <directory name="vendor" />
+            <directory name="vendor"/>
         </ignoreFiles>
     </projectFiles>
     <disableExtensions>
         <extension name="random"/>
         <extension name="redis"/>
     </disableExtensions>
+    <plugins>
+        <pluginClass class="Psalm\LaravelPlugin\Plugin">
+            <experimental value="true"/>
+            <failOnInternalError value="true"/>
+        </pluginClass>
+        <pluginClass class="InteractionDesignFoundation\PsalmLaravelNova\Plugin"/>
+    </plugins>
 </psalm>

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -8,6 +8,7 @@ use Laravel\Nova\Nova;
 /**
  * @phpcs:disable SlevomatCodingStandard.Classes.RequireAbstractOrFinal
  * @noRector \Rector\Privatization\Rector\Class_\FinalizeClassesWithoutChildrenRector
+ * @api
  */
 class ServiceProvider extends BasicServiceProvider
 {

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -14,7 +14,7 @@ class ServiceProvider extends BasicServiceProvider
     /** Bootstrap any application services. */
     public function boot(): void
     {
-        Nova::serving(static function () {
+        Nova::serving(static function (): void {
             Nova::script('nova-unlayer-field', __DIR__.'/../dist/js/field.js');
         });
 

--- a/src/Unlayer.php
+++ b/src/Unlayer.php
@@ -17,8 +17,8 @@ class Unlayer extends Field
 {
     use SupportsDependentFields;
 
-    public const MODE_EMAIL = 'email';
-    public const MODE_WEB = 'web';
+    public const string MODE_EMAIL = 'email';
+    public const string MODE_WEB = 'web';
 
     /**
      * The field's component.

--- a/src/Unlayer.php
+++ b/src/Unlayer.php
@@ -12,6 +12,7 @@ use Laravel\Nova\Http\Requests\NovaRequest;
  * @phpcs:disable SlevomatCodingStandard.TypeHints.ReturnTypeHint.UselessAnnotation
  * @phpcs:disable SlevomatCodingStandard.Classes.RequireAbstractOrFinal
  * @noRector \Rector\Privatization\Rector\Class_\FinalizeClassesWithoutChildrenRector
+ * @api
  */
 class Unlayer extends Field
 {
@@ -28,7 +29,8 @@ class Unlayer extends Field
 
     /**
      * Indicates if the element should be shown on the index view.
-     * @var (callable():bool)|bool
+     * @var bool|(callable(\Laravel\Nova\Http\Requests\NovaRequest, array<array-key, mixed>|object): bool)
+     * @phpcsSuppress SlevomatCodingStandard.TypeHints.DisallowMixedTypeHint
      */
     public $showOnIndex = false;
 
@@ -60,7 +62,10 @@ class Unlayer extends Field
         ]);
     }
 
-    /** @param (callable(\Laravel\Nova\Http\Requests\NovaRequest, string, \Illuminate\Database\Eloquent\Model, string): void)|null $callback */
+    /**
+     * @param (callable(\Laravel\Nova\Http\Requests\NovaRequest, string, \Illuminate\Database\Eloquent\Model, string): void)|null $callback
+     * @psalm-external-mutation-free
+     */
     final public function savingCallback(?callable $callback): static
     {
         $this->savingCallback = $callback;
@@ -91,7 +96,10 @@ class Unlayer extends Field
         return $this->withMeta(['plugins' => $plugins]);
     }
 
-    /** Set the Code editor to display all of its contents. */
+    /**
+     * Set the Code editor to display all of its contents.
+     * @psalm-external-mutation-free
+     */
     public function fullHeight(): static
     {
         $this->height = '100%';
@@ -99,7 +107,10 @@ class Unlayer extends Field
         return $this;
     }
 
-    /** Set the visual height of the Code editor to automatic. */
+    /**
+     * Set the visual height of the Code editor to automatic.
+     * @psalm-external-mutation-free
+     */
     public function autoHeight(): static
     {
         $this->height = 'auto';
@@ -107,7 +118,10 @@ class Unlayer extends Field
         return $this;
     }
 
-    /** Set the visual height of the Unlayer editor (with units). */
+    /**
+     * Set the visual height of the Unlayer editor (with units).
+     * @psalm-external-mutation-free
+     */
     public function height(string $height): static
     {
         $this->height = $height;
@@ -120,6 +134,7 @@ class Unlayer extends Field
      * @return array<string, mixed>
      * @phpcsSuppress SlevomatCodingStandard.TypeHints.DisallowMixedTypeHint
      */
+    #[\Override]
     public function jsonSerialize(): array
     {
         return array_merge(parent::jsonSerialize(), [
@@ -136,15 +151,19 @@ class Unlayer extends Field
      * @param string $attribute
      * @return void
      */
-    protected function fillAttributeFromRequest(NovaRequest $request, $requestAttribute, $model, $attribute): void
-    {
+    #[\Override]
+    protected function fillAttributeFromRequest(
+        NovaRequest $request,
+        string $requestAttribute,
+        object $model,
+        string $attribute
+    ): void {
         if (is_callable($this->savingCallback)) {
             call_user_func($this->savingCallback, $request, $requestAttribute, $model, "{$requestAttribute}_html");
         }
 
         if ($request->exists($requestAttribute)) {
-            $attributeValue = json_decode($request->get($requestAttribute), true);
-            $model->setAttribute($attribute, $attributeValue);
+            $model->setAttribute($attribute, json_decode((string) $request->string($requestAttribute), true));
         }
     }
 

--- a/tests/UnlayerTest.php
+++ b/tests/UnlayerTest.php
@@ -39,7 +39,7 @@ final class UnlayerTest extends TestCase
             public string $html = '';
         };
         $field = Unlayer::make('Design', 'design')
-            ->savingCallback(static function (NovaRequest $request, $attribute, Model $model, $outputHtmlFieldName) {
+            ->savingCallback(static function (NovaRequest $request, $attribute, Model $model, $outputHtmlFieldName): void {
                 $model->html = $request->input($outputHtmlFieldName);
             });
 


### PR DESCRIPTION
## Why

CI is red on `main`. The merged `coding-standard ^1.0-RC1` requires PHP `^8.4`, but the test matrix still ran PHP 8.2/8.3, so `composer update` could not resolve on those versions. This blocks every open PR.

## Changes

- Bump `require.php` to `^8.4` (matches coding-standard 1.0-RC1). Drop 8.2/8.3 from the CI matrix.
- `phpunit/phpunit` to `^12.4`. Version 13.x pulls `sebastian/diff 9`, which conflicts with Psalm 7 beta.
- Upgrade Psalm to `^7.0.0-beta19`. Add `psalm/plugin-laravel` and `interaction-design-foundation/psalm-laravel-nova`, both enabled in `psalm.xml` (Laravel plugin runs with `experimental` and `failOnInternalError`).
- Regenerate the Psalm baseline. Add declared types to the `MODE_*` constants (removes a cache-nondeterministic finding).
- Align composer CS scripts with the coding-standard recommended setup (`cs`, `php-cs-fixer`, `phpcbf`, `phpcs`) and apply php-cs-fixer fixes.
- Ignore `.php-cs-fixer.cache` and `/.cache`.

## Verification

Locally on PHP 8.5: `composer test`, `composer phpcs`, `composer psalm` (cold and warm cache), and php-cs-fixer dry-run all pass. Composer resolution confirmed for both matrix legs (L12 + testbench 10, L13 + testbench 11).